### PR TITLE
SmartWaiver boolean parameters are case senstive so need to converted…

### DIFF
--- a/SmartWaiver.Net/Clients/SearchClient.cs
+++ b/SmartWaiver.Net/Clients/SearchClient.cs
@@ -44,7 +44,7 @@ namespace SmartWaiver.Net.Clients
 
             if (verified != null)
             {
-                request.AddParameter("verified", verified.ToString());
+                request.AddParameter("verified", verified.ToString().ToLower());
             }
 
             if (sort != null)


### PR DESCRIPTION
… to lowercase.