### PR TITLE
Pass on Retry after value in event of Too Many Requests rate limit

### DIFF
--- a/SmartWaiver.Net/Clients/SearchClient.cs
+++ b/SmartWaiver.Net/Clients/SearchClient.cs
@@ -125,6 +125,9 @@ namespace SmartWaiver.Net.Clients
 
             ex.Data.Add("Guid", guid);
             ex.Data.Add("Page", page);
+            var retryAfter = response.Headers.FirstOrDefault(fod => fod.Name == "Retry-After");
+            if (retryAfter != null)
+                ex.Data.Add("Retry after", retryAfter.Value);
             if (pdf != null)
             {
                 ex.Data.Add("Pdf", pdf);

--- a/SmartWaiver.Net/Clients/WaiverClient.cs
+++ b/SmartWaiver.Net/Clients/WaiverClient.cs
@@ -37,11 +37,14 @@ namespace SmartWaiver.Net.Clients
             if (response.IsSuccessful)
             {
                 return response.Data;
-            }
+            } 
 
             var ex = new FailedToFetchFromAPIException($"Failed to fetch waiver {waiverId}",
                 response.ErrorException);
             ex.Data.Add("Waiver Id", waiverId);
+            var retryAfter = response.Headers.FirstOrDefault(fod=>fod.Name=="Retry-After");
+            if(retryAfter != null)
+                ex.Data.Add("Retry after", retryAfter.Value);
             ex.AddWebTrace(response.Content);
             throw ex;
         }
@@ -148,6 +151,9 @@ namespace SmartWaiver.Net.Clients
             var ex = new FailedToFetchFromAPIException($"Failed to fetch waiver {waiverId}",
                 response.ErrorException);
             ex.Data.Add("Waiver Id", waiverId);
+            var retryAfter = response.Headers.FirstOrDefault(fod => fod.Name == "Retry-After");
+            if (retryAfter != null)
+                ex.Data.Add("Retry after", retryAfter.Value);
             ex.AddWebTrace(response.Content);
             throw ex;
         }


### PR DESCRIPTION
In the event of '429 Too Many Requests' a retry after (seconds) value will be added to the response header.

Pass the value back if it exists.